### PR TITLE
fix: Use x509 instance to verify signatures

### DIFF
--- a/packages/certificate-check/src/main/CertUtil.ts
+++ b/packages/certificate-check/src/main/CertUtil.ts
@@ -122,8 +122,9 @@ function verifyPinning(hostname: string, certificate: ElectronCertificate): Pinn
 
     if (url.test(hostname.toLowerCase().trim())) {
       if (issuerRootPubkeys.length > 0) {
+        const x509 = new rs.X509();
         result.verifiedIssuerRootPubkeys = issuerRootPubkeys.some(pubkey =>
-          rs.X509.verifySignature(issuerCertHex, rs.KEYUTIL.getKey(pubkey))
+          x509.verifySignature(issuerCertHex, rs.KEYUTIL.getKey(pubkey))
         );
         if (!result.verifiedIssuerRootPubkeys) {
           const pubkeysCombined = issuerRootPubkeys.join(', ');


### PR DESCRIPTION
See http://kjur.github.io/jsrsasign/api/symbols/X509.html#verifySignature.