### PR TITLE
fix(build-tools): Write productName when building (WEBAPP-6106)

### DIFF
--- a/packages/build-tools/src/cli/build-linux-cli.ts
+++ b/packages/build-tools/src/cli/build-linux-cli.ts
@@ -120,7 +120,7 @@ logger.info(
   `Building ${commonConfig.name} ${commonConfig.version} for Linux (targets: ${linuxConfig.targets.join(', ')})...`
 );
 
-writeJson(electronPackageJson, {...originalElectronJson, version: commonConfig.version})
+writeJson(electronPackageJson, {...originalElectronJson, productName: commonConfig.name, version: commonConfig.version})
   .then(() => writeJson(wireJsonResolved, commonConfig))
   .then(() => electronBuilder.build({config: builderConfig, targets}))
   .then(buildFiles => buildFiles.forEach(buildFile => logger.log(`Built package "${buildFile}".`)))

--- a/packages/build-tools/src/cli/build-windows-cli.ts
+++ b/packages/build-tools/src/cli/build-windows-cli.ts
@@ -21,6 +21,7 @@
 
 import commander from 'commander';
 import electronPackager from 'electron-packager';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import {checkCommanderOptions, getLogger, getToolName, writeJson} from '../lib/build-utils';
@@ -39,6 +40,8 @@ checkCommanderOptions(commander, ['wireJson']);
 
 const wireJsonResolved = path.resolve(commander.wireJson);
 const {commonConfig, defaultConfig} = getCommonConfig({envFile: '.env.defaults', wireJson: wireJsonResolved});
+const electronPackageJson = path.resolve(commonConfig.electronDirectory, 'package.json');
+const originalElectronJson = fs.readJsonSync(electronPackageJson);
 
 const packagerOptions: electronPackager.Options = {
   appCopyright: commonConfig.copyright,
@@ -68,10 +71,13 @@ logEntries(commonConfig, 'commonConfig', toolName);
 
 logger.info(`Building ${commonConfig.name} ${commonConfig.version} for Windows ...`);
 
-writeJson(wireJsonResolved, commonConfig)
+writeJson(electronPackageJson, {...originalElectronJson, productName: commonConfig.name, version: commonConfig.version})
+  .then(() => writeJson(wireJsonResolved, commonConfig))
   .then(() => electronPackager(packagerOptions))
   .then(([buildDir]) => logger.log(`Built package in "${buildDir}".`))
-  .finally(() => writeJson(wireJsonResolved, defaultConfig))
+  .finally(() =>
+    Promise.all([writeJson(wireJsonResolved, defaultConfig), writeJson(electronPackageJson, originalElectronJson)])
+  )
   .catch(error => {
     logger.error(error);
     process.exit(1);


### PR DESCRIPTION
> You should usually also specify a `productName` field, which is your application's full capitalized `name`, and which will be preferred over name by Electron.

https://electronjs.org/docs/api/app#appgetname