### PR TITLE
refactor(build-tools): Use single package.json

### DIFF
--- a/packages/build-tools/src/cli/build-linux-cli.ts
+++ b/packages/build-tools/src/cli/build-linux-cli.ts
@@ -41,8 +41,8 @@ checkCommanderOptions(commander, ['wireJson']);
 
 const wireJsonResolved = path.resolve(commander.wireJson);
 const {commonConfig, defaultConfig} = getCommonConfig({envFile: '.env.defaults', wireJson: wireJsonResolved});
-const electronPackageJson = path.resolve(commonConfig.electronDirectory, 'package.json');
-const originalElectronJson = fs.readJsonSync(electronPackageJson);
+const packageJson = path.resolve('package.json');
+const originalPackageJson = fs.readJsonSync(packageJson);
 
 const linuxDefaultConfig: LinuxConfig = {
   /* tslint:disable:no-invalid-template-strings */
@@ -120,13 +120,11 @@ logger.info(
   `Building ${commonConfig.name} ${commonConfig.version} for Linux (targets: ${linuxConfig.targets.join(', ')})...`
 );
 
-writeJson(electronPackageJson, {...originalElectronJson, productName: commonConfig.name, version: commonConfig.version})
+writeJson(packageJson, {...originalPackageJson, productName: commonConfig.name, version: commonConfig.version})
   .then(() => writeJson(wireJsonResolved, commonConfig))
   .then(() => electronBuilder.build({config: builderConfig, targets}))
   .then(buildFiles => buildFiles.forEach(buildFile => logger.log(`Built package "${buildFile}".`)))
-  .finally(() =>
-    Promise.all([writeJson(wireJsonResolved, defaultConfig), writeJson(electronPackageJson, originalElectronJson)])
-  )
+  .finally(() => Promise.all([writeJson(wireJsonResolved, defaultConfig), writeJson(packageJson, originalPackageJson)]))
   .catch(error => {
     logger.error(error);
     process.exit(1);

--- a/packages/build-tools/src/cli/build-linux-cli.ts
+++ b/packages/build-tools/src/cli/build-linux-cli.ts
@@ -90,7 +90,6 @@ const builderConfig: electronBuilder.Configuration = {
     depends: debDepends,
   },
   directories: {
-    app: commonConfig.electronDirectory,
     buildResources: 'resources',
     output: 'wrap/dist',
   },

--- a/packages/build-tools/src/cli/build-macos-cli.ts
+++ b/packages/build-tools/src/cli/build-macos-cli.ts
@@ -41,8 +41,8 @@ checkCommanderOptions(commander, ['wireJson']);
 
 const wireJsonResolved = path.resolve(commander.wireJson);
 const {commonConfig, defaultConfig} = getCommonConfig({envFile: '.env.defaults', wireJson: wireJsonResolved});
-const electronPackageJson = path.resolve(commonConfig.electronDirectory, 'package.json');
-const originalElectronJson = fs.readJsonSync(electronPackageJson);
+const packageJson = path.resolve('package.json');
+const originalPackageJson = fs.readJsonSync(packageJson);
 
 const macOsDefaultConfig: MacOSConfig = {
   bundleId: 'com.wearezeta.zclient.mac',
@@ -102,13 +102,11 @@ logEntries(commonConfig, 'commonConfig', toolName);
 
 logger.info(`Building ${commonConfig.name} ${commonConfig.version} for macOS ...`);
 
-writeJson(electronPackageJson, {...originalElectronJson, productName: commonConfig.name, version: commonConfig.version})
+writeJson(packageJson, {...originalPackageJson, productName: commonConfig.name, version: commonConfig.version})
   .then(() => writeJson(wireJsonResolved, commonConfig))
   .then(() => electronPackager(packagerOptions))
   .then(([buildDir]) => logger.log(`Built package in "${buildDir}".`))
-  .finally(() =>
-    Promise.all([writeJson(wireJsonResolved, defaultConfig), writeJson(electronPackageJson, originalElectronJson)])
-  )
+  .finally(() => Promise.all([writeJson(wireJsonResolved, defaultConfig), writeJson(packageJson, originalPackageJson)]))
   .catch(error => {
     logger.error(error);
     process.exit(1);

--- a/packages/build-tools/src/cli/build-macos-cli.ts
+++ b/packages/build-tools/src/cli/build-macos-cli.ts
@@ -70,7 +70,7 @@ const packagerOptions: electronPackager.Options = {
   asar: true,
   buildVersion: commonConfig.buildNumber,
   darwinDarkModeSupport: true,
-  dir: commonConfig.electronDirectory,
+  dir: '.',
   extendInfo: 'resources/macos/custom.plist',
   helperBundleId: `${macOsConfig.bundleId}.helper`,
   icon: 'resources/macos/logo.icns',

--- a/packages/build-tools/src/cli/build-windows-cli.ts
+++ b/packages/build-tools/src/cli/build-windows-cli.ts
@@ -40,8 +40,8 @@ checkCommanderOptions(commander, ['wireJson']);
 
 const wireJsonResolved = path.resolve(commander.wireJson);
 const {commonConfig, defaultConfig} = getCommonConfig({envFile: '.env.defaults', wireJson: wireJsonResolved});
-const electronPackageJson = path.resolve(commonConfig.electronDirectory, 'package.json');
-const originalElectronJson = fs.readJsonSync(electronPackageJson);
+const packageJson = path.resolve('package.json');
+const originalPackageJson = fs.readJsonSync(packageJson);
 
 const packagerOptions: electronPackager.Options = {
   appCopyright: commonConfig.copyright,
@@ -71,13 +71,11 @@ logEntries(commonConfig, 'commonConfig', toolName);
 
 logger.info(`Building ${commonConfig.name} ${commonConfig.version} for Windows ...`);
 
-writeJson(electronPackageJson, {...originalElectronJson, productName: commonConfig.name, version: commonConfig.version})
+writeJson(packageJson, {...originalPackageJson, productName: commonConfig.name, version: commonConfig.version})
   .then(() => writeJson(wireJsonResolved, commonConfig))
   .then(() => electronPackager(packagerOptions))
   .then(([buildDir]) => logger.log(`Built package in "${buildDir}".`))
-  .finally(() =>
-    Promise.all([writeJson(wireJsonResolved, defaultConfig), writeJson(electronPackageJson, originalElectronJson)])
-  )
+  .finally(() => Promise.all([writeJson(wireJsonResolved, defaultConfig), writeJson(packageJson, originalPackageJson)]))
   .catch(error => {
     logger.error(error);
     process.exit(1);

--- a/packages/build-tools/src/cli/build-windows-cli.ts
+++ b/packages/build-tools/src/cli/build-windows-cli.ts
@@ -49,7 +49,7 @@ const packagerOptions: electronPackager.Options = {
   arch: 'ia32',
   asar: true,
   buildVersion: commonConfig.buildNumber,
-  dir: commonConfig.electronDirectory,
+  dir: '.',
   icon: `${commonConfig.electronDirectory}/img/logo.ico`,
   ignore: new RegExp(`${commonConfig.electronDirectory}/renderer/src`),
   name: commonConfig.name,


### PR DESCRIPTION
In preparation for https://github.com/wireapp/wire-desktop/pull/2427.